### PR TITLE
docs: Add template PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,8 @@
 ## Checklist
 
 - [ ] Realizei uma auto-revisão do meu código
-- [ ] Fiz as alterações correspondentes na documentação
+- [ ] Foi realizado uma revisão por outra pessoa do meu código
+- [ ] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
 - [ ] Meu código segue as diretrizes de estilo deste projeto
 - [ ] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
 - [ ] Testes de unidade novos e existentes são aprovados localmente com minhas alterações

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## O que foi realizado?
+
+<!--- Descreva suas alterações em detalhes -->
+
+## Checklist
+
+- [ ] Realizei uma auto-revisão do meu código
+- [ ] Fiz as alterações correspondentes na documentação
+- [ ] Meu código segue as diretrizes de estilo deste projeto
+- [ ] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
+- [ ] Testes de unidade novos e existentes são aprovados localmente com minhas alterações


### PR DESCRIPTION
### O que foi realizado?

Adicionei um template para padronizar comunicação dos PRs.  Preview em anexo.

<img width="1110" alt="Screen Shot 2022-07-25 at 17 07 49" src="https://user-images.githubusercontent.com/1703378/180865396-0d44d556-0ea1-464a-a5ab-e34b67a82001.png">


Obs.: 
 - Template baseado na doc Padrões de documentação no desenvolvimento. 
 -  Mais informações sobre [template PR](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) 

