### PR TITLE
refactor/import: Add tool to organize imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,35 @@
         ]
       }
     ],
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object",
+          "type"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          },
+          {
+            "pattern": ".css",
+            "group": "type",
+            "position": "after"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["react"],
+        "newlines-between": "never"
+      }
+    ],
     "no-console": ["warn", { "allow": ["warn", "error"] }],
     "no-nested-ternary": "off",
     "no-shadow": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2725,6 +2725,74 @@
         }
       }
     },
+    "@pkgr/utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.0.tgz",
+      "integrity": "sha512-7dIJ9CRVzBnqyEl7diUHPUFJf/oty2SeoVzcMocc5PeOUDK9KGzvgIBjGRRzzlRDaOjh3ADwH0WeibQvi3ls2Q==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "is-glob": "^4.0.3",
+        "open": "^8.4.0",
+        "picocolors": "^1.0.0",
+        "tiny-glob": "^0.2.9",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "open": {
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+          "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+          "dev": true,
+          "requires": {
+            "define-lazy-prop": "^2.0.0",
+            "is-docker": "^2.1.1",
+            "is-wsl": "^2.2.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
@@ -6248,6 +6316,12 @@
         "clone": "^1.0.2"
       }
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -7120,13 +7194,64 @@
         }
       }
     },
-    "eslint-module-utils": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
-      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+    "eslint-import-resolver-typescript": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.4.0.tgz",
+      "integrity": "sha512-rBCgiEovwX/HQ8ESWV+XIWZaFiRtDeAXNZdcTATB8UbMuadc9qfGOlIP+vy+c7nsgfEBN4NTwy5qunGNptDP0Q==",
+      "dev": true,
       "requires": {
-        "debug": "^3.2.7",
-        "find-up": "^2.1.0"
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.10.0",
+        "get-tsconfig": "^4.2.0",
+        "globby": "^13.1.2",
+        "is-core-module": "^2.9.0",
+        "is-glob": "^4.0.3",
+        "synckit": "^0.8.1"
+      },
+      "dependencies": {
+        "enhanced-resolve": {
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+          "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.4",
+            "tapable": "^2.2.0"
+          }
+        },
+        "globby": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+          "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+          "dev": true
+        },
+        "tapable": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+      "requires": {
+        "debug": "^3.2.7"
       },
       "dependencies": {
         "debug": {
@@ -7136,49 +7261,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         }
       }
     },
@@ -8388,6 +8470,12 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "get-tsconfig": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.2.0.tgz",
+      "integrity": "sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==",
+      "dev": true
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -8481,6 +8569,12 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -8493,6 +8587,12 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -16289,6 +16389,16 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
+    "synckit": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.3.tgz",
+      "integrity": "sha512-1goXnDYNJlKwCM37f5MTzRwo+8SqutgVtg2d37D6YnHHT4E3IhQMRfKiGdfTZU7LBlI6T8inCQUxnMBFHrbqWw==",
+      "dev": true,
+      "requires": {
+        "@pkgr/utils": "^2.3.0",
+        "tslib": "^2.4.0"
+      }
+    },
     "table": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
@@ -16623,6 +16733,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A=="
     },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
     "tiny-invariant": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
@@ -16853,7 +16973,8 @@
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "react-viewer": "^3.2.2",
     "sass": "^1.37.5",
     "serve": "^12.0.0",
-    "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
   },
   "scripts": {
@@ -30,7 +29,7 @@
     "build": "react-scripts build",
     "lint": "npx eslint 'src/**/**/**/**' --ext .tsx,.ts",
     "lint:fix": "npx eslint 'src/**/**/**/**' --fix",
-    "lint:format": "npx prettier --write 'src/**/**/**/**/*.ts' 'src/**/**/**/**/*.tsx' ",    
+    "lint:format": "npx prettier --write 'src/**/**/**/**/*.ts' 'src/**/**/**/**/*.tsx' ",
     "test": "react-scripts test --passWithNoTests",
     "test-husky": "react-scripts test --watchAll=false --bail",
     "test-coverage": "react-scripts test --watchAll=false --coverage",
@@ -86,20 +85,22 @@
     "@types/react-dom": "^17.0.17",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
-    "@typescript-eslint/parser": "^4.28.5",
+    "@typescript-eslint/parser": "^4.33.0",
     "commitizen": "^4.2.4",
     "conventional-changelog-conventionalcommits": "^4.6.0",
     "cz-customizable": "^6.3.0",
     "eslint": "^7.0.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint-import-resolver-typescript": "^3.4.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "4.2.0",
     "husky": "^7.0.0",
-    "prettier": "^2.3.2"
+    "prettier": "^2.3.2",
+    "typescript": "^4.7.4"
   },
   "config": {
     "commitizen": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { createTheme } from '@material-ui/core';
 import { ptBR } from '@material-ui/core/locale';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { AuthProvider } from 'modules/authentication/contexts/AuthContext';
-import { BrowserRouter as Router } from 'react-router-dom';
 import 'react-toastify/dist/ReactToastify.css';
 import { ToastContainer } from 'shared/components';
 import Routes from './routes/Routes';

--- a/src/modules/authentication/pages/LoginPage/LoginPage.test.tsx
+++ b/src/modules/authentication/pages/LoginPage/LoginPage.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LoginService from '../../services/LoginService';
-import LoginPage from './LoginPage';
 import { renderWithRouterAndAuth } from '../../../../setupTests';
+import LoginPage from './LoginPage';
 
 jest.mock('../../services/LoginService', () => {
   return {

--- a/src/modules/authentication/pages/LoginPage/LoginPage.tsx
+++ b/src/modules/authentication/pages/LoginPage/LoginPage.tsx
@@ -1,3 +1,5 @@
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import {
   Button,
   FormHelperText,
@@ -10,8 +12,6 @@ import Visibility from '@material-ui/icons/Visibility';
 import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import ErrorIcon from '@material-ui/icons/Error';
 import { useFormControls } from 'modules/authentication/hooks/index';
-import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
 import { LogoBPR } from '../../../../shared/assets/index';
 import { useHandleAuth } from '../../contexts/AuthContext';
 import LoginService from '../../services/LoginService';

--- a/src/modules/authentication/services/LoginService.test.ts
+++ b/src/modules/authentication/services/LoginService.test.ts
@@ -1,5 +1,5 @@
-import LoginService from './LoginService';
 import { auth } from '../../../shared/services/firebase';
+import LoginService from './LoginService';
 
 jest.mock('../../../shared/services/firebase', () => {
   return {

--- a/src/modules/bicycles/services/BikeService.test.ts
+++ b/src/modules/bicycles/services/BikeService.test.ts
@@ -1,9 +1,9 @@
 import { act, waitFor } from '@testing-library/react';
-import BikeService from './BikeService';
-import api from '../../../shared/services/api';
-import { mockedBikes, mockedBike } from '../mocks/BikeMocks';
+import api from 'shared/services/api';
+import { mockedBike } from '../mocks/BikeMocks';
 import Bike from '../models/Bike';
 import AmountBikesPerCommunity from '../utils/AmountBikesPerCommunity';
+import BikeService from './BikeService';
 
 jest.mock('shared/services/api');
 const mockedApi = api as jest.Mocked<typeof api>;

--- a/src/modules/bicycles/services/BikeService.ts
+++ b/src/modules/bicycles/services/BikeService.ts
@@ -1,6 +1,6 @@
+import { AxiosError } from 'axios';
 import Bike from 'modules/bicycles/models/Bike';
 import api from 'shared/services/api';
-import { AxiosError } from 'axios';
 import AmountBikesPerCommunity from '../utils/AmountBikesPerCommunity';
 
 const BikeService = {

--- a/src/modules/communities/pages/CommunityPage/CommunitiesDisplay/CommunitiesDisplayPage.test.tsx
+++ b/src/modules/communities/pages/CommunityPage/CommunitiesDisplay/CommunitiesDisplayPage.test.tsx
@@ -1,3 +1,4 @@
+import { BrowserRouter } from 'react-router-dom';
 import {
   act,
   render,
@@ -5,13 +6,12 @@ import {
   waitForElementToBeRemoved,
   fireEvent,
 } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
 import CommunityService from 'modules/communities/services/CommunityService';
-import CommunityDisplayPage from './CommunitiesDisplayPage';
 import {
   MockedFirstCommunity,
   MockedSecondCommunity,
 } from '../../../mocks/MockedCommunity';
+import CommunityDisplayPage from './CommunitiesDisplayPage';
 
 jest.mock('../../../services/CommunityService');
 const mockedCommunityService = CommunityService as jest.Mocked<

--- a/src/modules/communities/pages/CommunityPage/CommunitiesDisplay/CommunitiesDisplayPage.tsx
+++ b/src/modules/communities/pages/CommunityPage/CommunitiesDisplay/CommunitiesDisplayPage.tsx
@@ -2,16 +2,16 @@ import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
+import { IconButton, InputAdornment, TextField } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
 import { Loading, toast } from 'shared/components';
 import EmptyState from 'shared/components/EmptyState/EmptyState';
 import { EmptyStateImage } from 'shared/assets/images';
-import { IconButton, InputAdornment, TextField } from '@material-ui/core';
-import SearchIcon from '@material-ui/icons/Search';
 import Community from '../../../models/Community';
 import CommunityService from '../../../services/CommunityService';
-import useStyles from './CommunitiesDisplayPage.styles';
 import CommunityCard from '../components/CommunityCard/CommunityCard';
 import CreateCommunityButton from '../components/CreateCommunityButton/CreateCommunityButton';
+import useStyles from './CommunitiesDisplayPage.styles';
 
 type CommunitiesDisplayType = {
   isSelectingCommunities: boolean;

--- a/src/modules/communities/pages/CommunityPage/CommunityManagementPage/CommunityManagementPage.test.tsx
+++ b/src/modules/communities/pages/CommunityPage/CommunityManagementPage/CommunityManagementPage.test.tsx
@@ -1,11 +1,11 @@
 import { waitFor, screen } from '@testing-library/react';
-import { renderWithRouterAndAuth } from '../../../../../setupTests';
 import { BrowserRouter } from 'react-router-dom';
-import CommunityManagementPage from './CommunityManagementPage';
-import { MockedFirstCommunity } from '../../../mocks/MockedCommunity';
 import CommunityService from 'modules/communities/services/CommunityService';
 import BikeService from 'modules/bicycles/services/BikeService';
 import { MockedAmountsBikesPerCommunity } from 'modules/bicycles/mocks/BikeMocks';
+import { MockedFirstCommunity } from '../../../mocks/MockedCommunity';
+import { renderWithRouterAndAuth } from '../../../../../setupTests';
+import CommunityManagementPage from './CommunityManagementPage';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -156,7 +156,7 @@ describe('Community Management Page', () => {
       mockedCommunityService.getCommunityById.mockResolvedValue(
         MockedFirstCommunity,
       );
-      
+
       mockedBikeService.getAmountFilteredBikesPerCommunity.mockRejectedValue(
         new Error(),
       );

--- a/src/modules/communities/pages/CommunityPage/components/CommunityCard/CommunityCard.tsx
+++ b/src/modules/communities/pages/CommunityPage/components/CommunityCard/CommunityCard.tsx
@@ -7,9 +7,9 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import { PlaceOutlined } from '@material-ui/icons';
-import useStyles from './CommunityCard.styles';
 import CommunityMenu from '../CommunityMenu/CommunityMenu';
 import Community from '../../../../models/Community';
+import useStyles from './CommunityCard.styles';
 
 interface CommunityCardProps {
   community: Community;

--- a/src/modules/communities/pages/CommunityPage/components/CommunityMenu/CommunityMenu.tsx
+++ b/src/modules/communities/pages/CommunityPage/components/CommunityMenu/CommunityMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Button, MenuItem, Menu } from '@material-ui/core';
 import { MoreHoriz, EditOutlined } from '@material-ui/icons';
-import { useHistory } from 'react-router-dom';
 import useStyles from './CommunityMenu.styles';
 
 interface CommunityMenuProps {

--- a/src/modules/communities/pages/CommunityPage/components/CreateCommunityButton/CreateCommunityButton.tsx
+++ b/src/modules/communities/pages/CommunityPage/components/CreateCommunityButton/CreateCommunityButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Button } from '@material-ui/core';
 import { useHistory } from 'react-router-dom';
+import { Button } from '@material-ui/core';
 import useStyles from './CreateCommunityButton.styles';
 
 const DeleteCommunityButton: React.FC = () => {

--- a/src/modules/communities/pages/CreateAndEditCommunity/CreateAndEditCommunity.test.tsx
+++ b/src/modules/communities/pages/CreateAndEditCommunity/CreateAndEditCommunity.test.tsx
@@ -1,7 +1,6 @@
+import { MemoryRouter } from 'react-router-dom';
 import { render, screen, act } from '@testing-library/react';
 import CommunityService from 'modules/communities/services/CommunityService';
-import { MemoryRouter } from 'react-router-dom';
-
 import EditCommunityPage from './CreateAndEditCommunity';
 
 const renderElement = () =>

--- a/src/modules/communities/pages/CreateAndEditCommunity/CreateAndEditCommunity.tsx
+++ b/src/modules/communities/pages/CreateAndEditCommunity/CreateAndEditCommunity.tsx
@@ -1,12 +1,12 @@
-import Community from 'modules/communities/models/Community';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import Community from 'modules/communities/models/Community';
 import CommunityService from 'modules/communities/services/CommunityService';
 import { Loading } from 'shared/components';
 import FormHeader from 'shared/components/FormHeader/FormHeader';
-import useStyles from './CreateAndEditCommunity.styles';
-import EditCommunityForm from './components/CommunityForm/CommunityForm';
 import DeleteCommunityButton from './components/DeleteCommunityButton/DeleteCommunityButton';
+import EditCommunityForm from './components/CommunityForm/CommunityForm';
+import useStyles from './CreateAndEditCommunity.styles';
 
 const EditCommunityPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/modules/communities/pages/CreateAndEditCommunity/components/CommunityForm/CommunityForm.tsx
+++ b/src/modules/communities/pages/CreateAndEditCommunity/components/CommunityForm/CommunityForm.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
 import {
   Button,
   Card,
@@ -8,10 +10,8 @@ import {
   CircularProgress,
 } from '@material-ui/core';
 import Community from 'modules/communities/models/Community';
-import { useForm } from 'react-hook-form';
 import { Input, toast } from 'shared/components';
 import CommunityService from 'modules/communities/services/CommunityService';
-import { useHistory } from 'react-router-dom';
 import useStyles from './CommunityForm.styles';
 
 interface EditCommunityProps {

--- a/src/modules/communities/pages/CreateAndEditCommunity/components/DeleteCommunityButton/DeleteCommunityButton.tsx
+++ b/src/modules/communities/pages/CreateAndEditCommunity/components/DeleteCommunityButton/DeleteCommunityButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import {
   Button,
   Dialog,
@@ -9,7 +10,6 @@ import {
 } from '@material-ui/core';
 import { InfoOutlined } from '@material-ui/icons';
 import CommunityService from 'modules/communities/services/CommunityService';
-import { useHistory } from 'react-router-dom';
 import { toast } from 'shared/components';
 import useStyles from './DeleteCommunityButton.styles';
 

--- a/src/modules/communities/services/CommunityService.test.ts
+++ b/src/modules/communities/services/CommunityService.test.ts
@@ -1,11 +1,11 @@
-import api from 'shared/services/api';
 import { act, waitFor } from '@testing-library/react';
-import CommunityService from './CommunityService';
+import api from 'shared/services/api';
 import Community from '../models/Community';
 import {
   MockedFirstCommunity,
   MockedSecondCommunity,
 } from '../mocks/MockedCommunity';
+import CommunityService from './CommunityService';
 
 jest.mock('shared/services/api');
 const mockedApi = api as jest.Mocked<typeof api>;

--- a/src/modules/dashboard/pages/DashboardPage/DashboardPage.tsx
+++ b/src/modules/dashboard/pages/DashboardPage/DashboardPage.tsx
@@ -1,5 +1,5 @@
-import DashboardService from 'modules/dashboard/services/DashboardService';
 import React, { FC, useEffect, useState } from 'react';
+import DashboardService from 'modules/dashboard/services/DashboardService';
 import { Loading } from 'shared/components';
 import DashboardInfo from '../../models/DashboardInfo';
 import Dashboard from './fragments/Dashboard/Dashboard';

--- a/src/modules/dashboard/pages/DashboardPage/components/ButtonGrid/ButtonGrid.tsx
+++ b/src/modules/dashboard/pages/DashboardPage/components/ButtonGrid/ButtonGrid.tsx
@@ -1,5 +1,5 @@
-import { Grid } from '@material-ui/core';
 import React, { FC } from 'react';
+import { Grid } from '@material-ui/core';
 
 const ButtonGrid: FC = ({ children }) => {
   return (

--- a/src/modules/dashboard/pages/DashboardPage/components/DashboardButton/DashboardButton.tsx
+++ b/src/modules/dashboard/pages/DashboardPage/components/DashboardButton/DashboardButton.tsx
@@ -1,6 +1,6 @@
+import React, { FC } from 'react';
 import { Button, Grid } from '@material-ui/core';
 import clsx from 'clsx';
-import React, { FC } from 'react';
 import DashboardButtonStyles from './DashboardButton.styles';
 
 interface DashboardButtonProps {

--- a/src/modules/dashboard/pages/DashboardPage/components/DonutPercentageCard/DonutPercentageCard.tsx
+++ b/src/modules/dashboard/pages/DashboardPage/components/DonutPercentageCard/DonutPercentageCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import Chart from 'react-apexcharts';
 import { Grid } from '@material-ui/core';
 import { StopRounded } from '@material-ui/icons';
-import Chart from 'react-apexcharts';
 import CustomCard from '../../../../../../shared/components/CustomCard/CustomCard';
 import DonutPercentageCardStyles from './DonutPercentageCard.styles';
 

--- a/src/modules/dashboard/pages/DashboardPage/fragments/Dashboard/Dashboard.tsx
+++ b/src/modules/dashboard/pages/DashboardPage/fragments/Dashboard/Dashboard.tsx
@@ -1,15 +1,15 @@
+import React, { FC } from 'react';
 import { Grid, Typography } from '@material-ui/core';
 import { useGetAuth } from 'modules/authentication/contexts/AuthContext';
 import DashboardInfo from 'modules/dashboard/models/DashboardInfo';
-import React, { FC } from 'react';
 import CustomCard from 'shared/components/CustomCard/CustomCard';
 import DashboardCard from 'shared/components/DashboardCard/DashboardCard';
 import HorizontalBarChart from 'shared/components/HorizontalBarChart/HorizontalBarChart';
 import VerticalBarChart from 'shared/components/VerticalBarChart/VerticalBarChart';
-import DonutPercentageCard from '../../components/DonutPercentageCard/DonutPercentageCard';
-import MultipleCharts from '../MultipleCharts/MultipleCharts';
-import DashboardStyles from './Dashboard.styles';
 import TravelTimeCard from '../../components/TravelTimeCard/TravelTimeCard';
+import MultipleCharts from '../MultipleCharts/MultipleCharts';
+import DonutPercentageCard from '../../components/DonutPercentageCard/DonutPercentageCard';
+import DashboardStyles from './Dashboard.styles';
 
 interface DashboardProps {
   dashboardData: DashboardInfo;

--- a/src/modules/dashboard/pages/DashboardPage/fragments/MultipleCharts/MultipleCharts.tsx
+++ b/src/modules/dashboard/pages/DashboardPage/fragments/MultipleCharts/MultipleCharts.tsx
@@ -1,12 +1,12 @@
-import { Grid } from '@material-ui/core';
 import React, { FC, useState } from 'react';
+import { Grid } from '@material-ui/core';
 import CustomCard from 'shared/components/CustomCard/CustomCard';
 import HorizontalBarChart from 'shared/components/HorizontalBarChart/HorizontalBarChart';
 import PolarAreaChart from 'shared/components/PolarAreaChart/PolarAreaChart';
 import VerticalBarChart from 'shared/components/VerticalBarChart/VerticalBarChart';
 import ChartDataProps from 'shared/models/ChartDataProps';
-import ButtonGrid from '../../components/ButtonGrid/ButtonGrid';
 import DashboardButton from '../../components/DashboardButton/DashboardButton';
+import ButtonGrid from '../../components/ButtonGrid/ButtonGrid';
 
 interface MultipleChartsProps {
   charts: { label: string; type: string }[];

--- a/src/modules/users/pages/UserDetailPage/UserDetailPage.test.tsx
+++ b/src/modules/users/pages/UserDetailPage/UserDetailPage.test.tsx
@@ -1,10 +1,10 @@
-import { act, render, waitFor } from '@testing-library/react';
 import { BrowserRouter, Router } from 'react-router-dom';
+import { act, render, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import UserDetailPage from './UserDetailPage';
 import UserService from '../../services/UserService';
 import { MockedFirstUser } from '../../mocks/MockedUser';
 import Route from '../../../../routes/Route';
+import UserDetailPage from './UserDetailPage';
 
 jest.mock('../../services/UserService');
 const mockedUserService = UserService as jest.Mocked<typeof UserService>;

--- a/src/modules/users/pages/UserDetailPage/UserDetailPage.tsx
+++ b/src/modules/users/pages/UserDetailPage/UserDetailPage.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Loading } from 'shared/components';
+import { Link, useParams } from 'react-router-dom';
 import { Typography } from '@material-ui/core';
 import { ArrowBackIos } from '@material-ui/icons';
-import { Link, useParams } from 'react-router-dom';
+import { Loading } from 'shared/components';
 import User from 'modules/users/models/User';
 import UserService from 'modules/users/services/UserService';
-import useStyles from './UserDetailPage.styles';
 import { UserDetailHeading, UserDetailInfo } from './components';
+import useStyles from './UserDetailPage.styles';
 
 const UserDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/modules/users/pages/UserDetailPage/components/UserDetailInfo/UserDetailInfo.test.tsx
+++ b/src/modules/users/pages/UserDetailPage/components/UserDetailInfo/UserDetailInfo.test.tsx
@@ -1,9 +1,9 @@
+import { BrowserRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import {
   MockedFirstUser,
   mockUserMissingInfo,
 } from 'modules/users/mocks/MockedUser';
-import { BrowserRouter } from 'react-router-dom';
 import UserDetailInfo from './UserDetailInfo';
 
 jest.mock('modules/users/services/UserService');

--- a/src/modules/users/pages/UserDetailPage/components/UserDetailInfo/UserDetailInfo.tsx
+++ b/src/modules/users/pages/UserDetailPage/components/UserDetailInfo/UserDetailInfo.tsx
@@ -1,11 +1,11 @@
-import User from 'modules/users/models/User';
-import { Grid, Typography, Avatar } from '@material-ui/core';
-import { LockOutlined, PlaceOutlined, PhoneOutlined } from '@material-ui/icons';
 import React, { useState } from 'react';
-import useStyles, { StyledBadgeUserDetail } from './UserDetailInfo.styles';
+import { LockOutlined, PlaceOutlined, PhoneOutlined } from '@material-ui/icons';
+import { Grid, Typography, Avatar } from '@material-ui/core';
+import User from 'modules/users/models/User';
 import UserService from '../../../../services/UserService';
 import UserDetailMenu from '../UserDetailMenu/UserDetailMenu';
 import { toast } from '../../../../../../shared/components';
+import useStyles, { StyledBadgeUserDetail } from './UserDetailInfo.styles';
 
 interface UserInfoProps {
   user: User;

--- a/src/modules/users/pages/UserPage/UserPage.test.tsx
+++ b/src/modules/users/pages/UserPage/UserPage.test.tsx
@@ -1,13 +1,13 @@
+import { BrowserRouter } from 'react-router-dom';
 import {
   act,
   render,
   screen,
   waitForElementToBeRemoved,
 } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
 import UserService from '../../services/UserService';
-import UserPage from './UserPage';
 import { MockedFirstUser, MockedSecondUser } from '../../mocks/MockedUser';
+import UserPage from './UserPage';
 
 jest.mock('../../services/UserService');
 const mockedUserService = UserService as jest.Mocked<typeof UserService>;

--- a/src/modules/users/pages/UserPage/UserPage.tsx
+++ b/src/modules/users/pages/UserPage/UserPage.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { Typography, Grid } from '@material-ui/core';
-import EmptyState from 'shared/components/EmptyState/EmptyState';
 import { EmptyStateImage } from 'shared/assets/images';
+import EmptyState from 'shared/components/EmptyState/EmptyState';
 import User from '../../models/User';
 import UserService from '../../services/UserService';
+import Loading from '../../../../shared/components/Loading/Loading';
 import UserCard from './components/UserCard/UserCard';
 import useStyles from './UserPage.styles';
-import Loading from '../../../../shared/components/Loading/Loading';
 
 const UserPage: React.FC = () => {
   const [users, setUsers] = useState<User[]>([]);

--- a/src/modules/users/pages/UserPage/components/UserCard/UserCard.test.tsx
+++ b/src/modules/users/pages/UserPage/components/UserCard/UserCard.test.tsx
@@ -1,3 +1,4 @@
+import { BrowserRouter } from 'react-router-dom';
 import {
   act,
   fireEvent,
@@ -5,7 +6,6 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
 import UserService from 'modules/users/services/UserService';
 import { MockedFirstUser } from 'modules/users/mocks/MockedUser';
 import UserCard from './UserCard';

--- a/src/modules/users/pages/UserPage/components/UserCard/UserCard.tsx
+++ b/src/modules/users/pages/UserPage/components/UserCard/UserCard.tsx
@@ -1,16 +1,16 @@
-import { Avatar, Card, CardContent, Typography, Grid } from '@material-ui/core';
-import { LockOutlined, PlaceOutlined } from '@material-ui/icons';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Avatar, Card, CardContent, Typography, Grid } from '@material-ui/core';
+import { LockOutlined, PlaceOutlined } from '@material-ui/icons';
 import { toast } from 'shared/components';
 import { GenderTypes } from 'modules/users/models/types/GenderTypes';
 import { RacialTypes } from 'modules/users/models/types/RacialTypes';
 import { SchoolingTypes } from 'modules/users/models/types/SchoolingTypes';
 import { SchoolingStatusTypes } from 'modules/users/models/types/SchoolingStatusTypes';
 import { IncomeTypes } from 'modules/users/models/types/IncomeTypes';
+import UserService from '../../../../services/UserService';
 import UserMenu from '../UserMenu/UserMenu';
 import useStyles, { StyledBadgeUserCard } from './UserCard.styles';
-import UserService from '../../../../services/UserService';
 
 interface UserCardProps {
   user: {

--- a/src/modules/users/services/UserService.test.ts
+++ b/src/modules/users/services/UserService.test.ts
@@ -1,8 +1,8 @@
 import { act, waitFor } from '@testing-library/react';
-import UserService from './UserService';
 import api from '../../../shared/services/api';
 import { MockedFirstUser, MockedSecondUser } from '../mocks/MockedUser';
 import User from '../models/User';
+import UserService from './UserService';
 
 jest.mock('shared/services/api');
 const mockedApi = api as jest.Mocked<typeof api>;

--- a/src/routes/Route.tsx
+++ b/src/routes/Route.tsx
@@ -1,10 +1,10 @@
-import { useGetAuth } from 'modules/authentication/contexts/AuthContext';
 import React from 'react';
 import {
   Redirect,
   Route as ReactDOMRoute,
   RouteProps as ReactRouteProps,
 } from 'react-router-dom';
+import { useGetAuth } from 'modules/authentication/contexts/AuthContext';
 
 interface RouteProps extends ReactRouteProps {
   isPrivate: boolean;

--- a/src/routes/Router.test.tsx
+++ b/src/routes/Router.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
-import Route from './Route';
 import { renderWithRouterAndAuth, setUserAuthenticated } from '../setupTests';
+import Route from './Route';
 
 describe('route redirections based on authentication', () => {
   it('should render public page', async () => {

--- a/src/routes/routesCoordinator.ts
+++ b/src/routes/routesCoordinator.ts
@@ -1,5 +1,5 @@
-import CommunityManagementPage from 'modules/communities/pages/CommunityPage/CommunityManagementPage/CommunityManagementPage';
 import { lazy } from 'react';
+import CommunityManagementPage from 'modules/communities/pages/CommunityPage/CommunityManagementPage/CommunityManagementPage';
 
 const CreateAndEditCommunityPage = lazy(
   () =>

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -4,9 +4,9 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import { render } from '@testing-library/react';
-import { Router } from 'react-router-dom';
 import { AuthProvider } from './modules/authentication/contexts/AuthContext';
 import AuthInterface from './modules/authentication/models/AuthInterface';
 

--- a/src/shared/components/CustomCard/CustomCard.tsx
+++ b/src/shared/components/CustomCard/CustomCard.tsx
@@ -1,6 +1,6 @@
+import React, { FC, ReactElement } from 'react';
 import { Card, CardContent, CardHeader } from '@material-ui/core';
 import clsx from 'clsx';
-import React, { FC, ReactElement } from 'react';
 import CustomCardStyles from './CustomCard.styles';
 
 interface CustomCardProps {

--- a/src/shared/components/CustomCardWithIcon/CustomCardWithIcon.test.tsx
+++ b/src/shared/components/CustomCardWithIcon/CustomCardWithIcon.test.tsx
@@ -5,16 +5,21 @@ jest.mock('../Icon/Icon', () => () => 'Icon-component-mock');
 
 describe('Component: CustomCardWithIcon', () => {
   it('should render correctly', () => {
-      render(
-        <CustomCardWithIcon id="my-id" text="My Text" iconName="lendBike" iconDescription="Teste" />,
-      );
+    render(
+      <CustomCardWithIcon
+        id="my-id"
+        text="My Text"
+        iconName="lendBike"
+        iconDescription="Teste"
+      />,
+    );
 
-      const title = screen.getByRole('heading', { name: /My Text/i });
-      const icon = screen.getByText('Icon-component-mock');
+    const title = screen.getByRole('heading', { name: /My Text/i });
+    const icon = screen.getByText('Icon-component-mock');
 
-      expect(title).toBeInTheDocument();
-      expect(title).toHaveAttribute('data-testid', 'my-id');
+    expect(title).toBeInTheDocument();
+    expect(title).toHaveAttribute('data-testid', 'my-id');
 
-      expect(icon).toBeInTheDocument();
-    });
+    expect(icon).toBeInTheDocument();
+  });
 });

--- a/src/shared/components/DashboardCard/DashboardCard.tsx
+++ b/src/shared/components/DashboardCard/DashboardCard.tsx
@@ -1,5 +1,5 @@
-import { Grid, Paper, Typography } from '@material-ui/core';
 import React, { FC } from 'react';
+import { Grid, Paper, Typography } from '@material-ui/core';
 import DashboardCardStyles from './DashboardCard.styles';
 
 interface DashboardCardProps {

--- a/src/shared/components/EmptyState/EmptyState.tsx
+++ b/src/shared/components/EmptyState/EmptyState.tsx
@@ -1,5 +1,5 @@
-import { Typography } from '@material-ui/core';
 import React from 'react';
+import { Typography } from '@material-ui/core';
 import useStyles from './EmptyState.style';
 
 type EmptyStateProps = {

--- a/src/shared/components/FormHeader/FormHeader.tsx
+++ b/src/shared/components/FormHeader/FormHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Typography } from '@material-ui/core';
 import { ArrowBackIos } from '@material-ui/icons';
-import { Link } from 'react-router-dom';
 import useStyles from './FormHeader.styles';
 
 interface FormHeaderProps extends React.HtmlHTMLAttributes<HTMLDivElement> {

--- a/src/shared/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/shared/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -1,7 +1,7 @@
-import { useTheme } from '@material-ui/core';
-import { ChartOptions } from 'chart.js';
 import { FC, useMemo } from 'react';
 import { Bar } from 'react-chartjs-2';
+import { useTheme } from '@material-ui/core';
+import { ChartOptions } from 'chart.js';
 import ChartDataProps from 'shared/models/ChartDataProps';
 
 interface HorizontalBarChartProps {

--- a/src/shared/components/Icon/Icon.test.tsx
+++ b/src/shared/components/Icon/Icon.test.tsx
@@ -10,7 +10,5 @@ describe('Component: Icon', () => {
 
     expect(componentId).toBeInTheDocument();
     expect(componentAlt).toBeInTheDocument();
-
   });
-
 });

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -1,5 +1,5 @@
-import { TextField } from '@material-ui/core';
 import { Controller } from 'react-hook-form';
+import { TextField } from '@material-ui/core';
 import { ErrorOutline } from '@material-ui/icons';
 import useStyles from './Input.styles';
 

--- a/src/shared/components/Menu/Menu.tsx
+++ b/src/shared/components/Menu/Menu.tsx
@@ -1,3 +1,5 @@
+import React, { FC, useCallback, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import {
   AppBar,
   Divider,
@@ -14,8 +16,6 @@ import {
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import MenuIcon from '@material-ui/icons/Menu';
 import clsx from 'clsx';
-import React, { FC, useCallback, useState } from 'react';
-import { useHistory } from 'react-router-dom';
 import { LogoBPRwhite, ArrowBack } from 'shared/assets';
 import {
   useClearAuth,

--- a/src/shared/components/PageTitle/PageTitle.test.tsx
+++ b/src/shared/components/PageTitle/PageTitle.test.tsx
@@ -6,7 +6,14 @@ jest.mock('../Icon/Icon', () => () => 'Icon-component-mock');
 describe('Component: PageTitle', () => {
   describe('should render correctly', () => {
     it('when has icon', () => {
-      render(<PageTitle id="my-id" text="My Text" iconName="gear" iconDescription='Ícone de configurações'/>);
+      render(
+        <PageTitle
+          id="my-id"
+          text="My Text"
+          iconName="gear"
+          iconDescription="Ícone de configurações"
+        />,
+      );
 
       const title = screen.getByRole('heading', { name: /My Text/i });
       const icon = screen.getByText('Icon-component-mock');

--- a/src/shared/components/PageTitle/PageTitle.tsx
+++ b/src/shared/components/PageTitle/PageTitle.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
-
-import Icon, { IconTypes } from 'shared/components/Icon/Icon';
 import { Box } from '@material-ui/core';
+import Icon, { IconTypes } from 'shared/components/Icon/Icon';
 import useStyles from './PageTitle.styles';
 
 interface Props {

--- a/src/shared/components/PolarAreaChart/PolarAreaChart.tsx
+++ b/src/shared/components/PolarAreaChart/PolarAreaChart.tsx
@@ -1,7 +1,7 @@
-import { useTheme } from '@material-ui/core';
-import { ChartOptions } from 'chart.js';
 import React, { FC, useMemo } from 'react';
 import { PolarArea } from 'react-chartjs-2';
+import { useTheme } from '@material-ui/core';
+import { ChartOptions } from 'chart.js';
 import ChartDataProps from 'shared/models/ChartDataProps';
 import { ColorsUtils } from 'shared/utils';
 

--- a/src/shared/components/Toast/Toast.tsx
+++ b/src/shared/components/Toast/Toast.tsx
@@ -1,8 +1,8 @@
-import { CheckCircleOutline, ErrorOutline } from '@material-ui/icons';
 import {
   toast as rtoast,
   ToastContainer as RToastContainer,
 } from 'react-toastify';
+import { CheckCircleOutline, ErrorOutline } from '@material-ui/icons';
 import useStyles from './Toast.styles';
 
 const toast = {

--- a/src/shared/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/src/shared/components/VerticalBarChart/VerticalBarChart.tsx
@@ -1,6 +1,6 @@
+import React, { FC, useMemo } from 'react';
 import { Avatar, Grid, Typography } from '@material-ui/core';
 import clsx from 'clsx';
-import React, { FC, useMemo } from 'react';
 import ChartDataProps from 'shared/models/ChartDataProps';
 import VerticalBarChartStyles from './VerticalBarChart.styles';
 


### PR DESCRIPTION
## O que foi realizado?

 - Adicionamos ferramenta pra organizar os imports (objetivo padronizar código)
 - Organização importa primeiro react e libs de terceiros depois nosso modulos internos (print com exemplo)
 
 Mais informações sobre ferramenta -> https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/order.md
 
![Screen Shot 2022-08-12 at 13 59 27](https://user-images.githubusercontent.com/1703378/184407799-44e1c968-b366-48ab-ba37-deb830689056.png) 

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [ ] Foi realizado uma revisão por outra pessoa do meu código
- [x] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
- [x] Meu código segue as diretrizes de estilo deste projeto
- [ ] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [ ] Testes de unidade novos e existentes são aprovados localmente com minhas alterações

## Checklist Frontend

- [ ] Inseri na PR captura de tela da feature desenvolvida 
