### PR TITLE
feat(users): Making default value for collision mandatory

### DIFF
--- a/src/modules/users/pages/RegisterUser/components/RegisterUserForm/components/ProblemsForm/ProblemsForm.test.tsx
+++ b/src/modules/users/pages/RegisterUser/components/RegisterUserForm/components/ProblemsForm/ProblemsForm.test.tsx
@@ -1,28 +1,31 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { renderWithRouterAndAuth } from 'setupTests';
 import RegisterUserForm from '../../RegisterUserForm';
+import ProblemsForm, { ProblemsFormProps } from './ProblemsForm';
+
+jest.mock('shared/components/Input/Input', () => () => `Input-component-mock`);
 
 describe('ProblemsForm', () => {
-  it('should have all fields required', async () => {
-    render(<RegisterUserForm />);
+  let defaultProps: ProblemsFormProps;
 
-    expect(screen.getByTestId('time-to-arrive-test')).toBeInTheDocument();
-    expect(screen.getByTestId('problems-test')).toBeInTheDocument();
-    expect(screen.getByTestId('been-collision-test')).toBeInTheDocument();
+  beforeEach(() => {
+    defaultProps = {
+      onChange: jest.fn(),
+      control: jest.fn(),
+      values: {
+        collision: 'No',
+        problems: '',
+        timeToArrive: '',
+      },
+    };
   });
 
-  it('should show error when submitting empty values', async () => {
-    const { getByText } = renderWithRouterAndAuth(<RegisterUserForm />);
-
-    await act(async () => {
-      fireEvent.click(getByText('CONCLUIR CADASTRO'));
-    });
+  it('should have all fields required', async () => {
+    render(<ProblemsForm {...defaultProps} />);
 
     expect(
-      screen.getByText('Citar problemas é obrigatório'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('Informar o tempo é obrigatório'),
-    ).toBeInTheDocument();
+      screen.queryAllByText('Input-component-mock').length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(screen.getByTestId('select-collision-test')).toBeInTheDocument();
   });
 });

--- a/src/modules/users/pages/RegisterUser/components/RegisterUserForm/components/ProblemsForm/ProblemsForm.tsx
+++ b/src/modules/users/pages/RegisterUser/components/RegisterUserForm/components/ProblemsForm/ProblemsForm.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
-import {
-  Card,
-  CardContent,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
-  Typography,
-} from '@material-ui/core';
-import { Input } from 'shared/components';
+import { Card, CardContent, Grid, Typography } from '@material-ui/core';
+import { Input, Select } from 'shared/components';
 import useStyles from './ProblemsForm.styles';
 
-interface ProblemsFormProps {
+export interface ProblemsFormProps {
   control: any;
   onChange: any;
   values: any;
@@ -31,21 +23,24 @@ const ProblemsForm: React.FC<ProblemsFormProps> = ({
         </Typography>
         <Grid container direction="row" spacing={3}>
           <Grid item xs={12} sm={12} md={12}>
-            <InputLabel id="collision-id" data-testid="been-collision-test">
-              Já foi vítima de colisão ou atropelamento?*
-            </InputLabel>
             <Select
+              id="collision"
+              label="Já foi vítima de colisão/atropelamento?"
               name="collision"
-              labelId="collision-label"
-              id="collision-select"
-              data-testid="collision-test"
-              value={values.collison}
+              dataTestId="collision-test"
+              value={values?.collision || 'No'}
               onChange={onChange}
-              className={classes.selectStyle}
-            >
-              <MenuItem value="Yes">Sim</MenuItem>
-              <MenuItem value="No">Não</MenuItem>
-            </Select>
+              options={[
+                {
+                  value: 'Yes',
+                  text: 'Sim',
+                },
+                {
+                  value: 'No',
+                  text: 'Não',
+                },
+              ]}
+            />
           </Grid>
           <Grid item xs={12} sm={6} md={6}>
             <Input


### PR DESCRIPTION
## O que foi realizado?

Foi removido o `Select` nativo do react do form e foi implementado o nosso `Select` customizado. Dessa forma o valor padrão é sempre passado ao backend.

<!--- Descreva suas alterações em detalhes -->

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [ ] Foi realizado uma revisão por outra pessoa do meu código
- [x] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes são aprovados localmente com minhas alterações

## Checklist Frontend

- [x] Inseri na PR captura de tela da feature desenvolvida 
