### PR TITLE
fix: Removing delete button from Editing community

### DIFF
--- a/src/modules/communities/pages/EditCommunityPage/EditCommunityPage.test.tsx
+++ b/src/modules/communities/pages/EditCommunityPage/EditCommunityPage.test.tsx
@@ -34,6 +34,9 @@ describe('Edit community', () => {
     expect(
       await screen.findByText('Editar Comunidade XPTO'),
     ).toBeInTheDocument();
+    expect(
+      await screen.queryByText('DELETAR COMUNIDADE'),
+    ).not.toBeInTheDocument();
   });
 
   it('renders page exception', async () => {

--- a/src/modules/communities/pages/EditCommunityPage/EditCommunityPage.tsx
+++ b/src/modules/communities/pages/EditCommunityPage/EditCommunityPage.tsx
@@ -7,7 +7,6 @@ import CommunityService from 'modules/communities/services/CommunityService';
 import { EmptyState, Loading } from 'shared/components';
 import FormHeader from 'shared/components/FormHeader/FormHeader';
 import CommunityForm from '../components/CommunityForm/CommunityForm';
-import DeleteCommunityButton from './components/DeleteCommunityButton/DeleteCommunityButton';
 import useStyles from './EditCommunityPage.styles';
 
 const EditCommunityPage: React.FC = () => {
@@ -45,7 +44,6 @@ const EditCommunityPage: React.FC = () => {
           ) : (
             <>
               <CommunityForm community={community} />
-              <DeleteCommunityButton communityId={id} />
             </>
           )}
         </div>


### PR DESCRIPTION
## O que foi realizado?

Seguindo a priorização da cliente removemos da edição de comunidades a habilidade de deletar uma comunidade.

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [ ] Foi realizado uma revisão por outra pessoa do meu código
- [x] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes são aprovados localmente com minhas alterações

## Checklist Frontend

- [x] Inseri na PR captura de tela da feature desenvolvida 
![Captura de Tela 2022-08-26 às 11 53 42](https://user-images.githubusercontent.com/107143825/186932911-0bdc711d-e7b2-446a-91f4-5a4bf0da624e.png)

