### PR TITLE
feat: Changing UI display to show <1% when data is irrelevant

### DIFF
--- a/src/modules/dashboard/pages/DashboardPage/components/DonutPercentageCard/DonutPercentageCard.tsx
+++ b/src/modules/dashboard/pages/DashboardPage/components/DonutPercentageCard/DonutPercentageCard.tsx
@@ -47,6 +47,9 @@ const DonutPercentageCard: React.FC<DonutProps> = ({
             fontWeight: 'bold',
             show: true,
             offsetY: 8,
+            formatter(val: number) {
+              return val < 1 ? '<1%' : `${val}%`;
+            },
           },
         },
       },


### PR DESCRIPTION
## O que foi realizado?

Quando o valor exibido nos gráficos da dashboard era muito pequeno o valor `0%` era exibido. A mudança serve para que agora, nestes casos, o valor exibido seja `<1%`.

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [x] Foi realizado uma revisão por outra pessoa do meu código
- [x] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes são aprovados localmente com minhas alterações

## Checklist Frontend

- [x] Inseri na PR captura de tela da feature desenvolvida
![Captura de Tela 2022-08-31 às 14 49 39](https://user-images.githubusercontent.com/107143825/187745710-c7adb303-cb16-4f61-a2e6-b007b2d4ff65.png)
