### PR TITLE
feat(communities): Community Selection filtering per manager

### DIFF
--- a/src/modules/communities/mocks/MockedCommunity.ts
+++ b/src/modules/communities/mocks/MockedCommunity.ts
@@ -11,13 +11,26 @@ export const MockedFirstCommunity: Community = {
   bicycles: [],
   withdrawals: [],
 };
+
+export const MockedLoggedInUserManager: Community = {
+  address: 'Recife',
+  created_date: new Date(),
+  description: 'Comunidade em Recife',
+  id: '-MLDOXs3p35DEHg0gdUU',
+  name: 'Comunidade Gerenciada',
+  org_email: 'email@example.com',
+  org_name: 'John',
+  bicycles: [],
+  withdrawals: [],
+};
+
 export const MockedSecondCommunity: Community = {
   address: 'Rua Teste, 123',
   created_date: new Date(),
   description: 'Descricao teste',
   id: '-MLy8y1-5v5GLg7Z428y',
   name: 'Nome Teste',
-  org_email: 'orgtest@orgtest.com',
+  org_email: 'email@example.com',
   org_name: 'Nome Org Teste',
   bicycles: [],
   withdrawals: [],

--- a/src/modules/communities/pages/CommunitiesPages/CommunitiesSelectionPage/CommunitiesSelectionPage.test.tsx
+++ b/src/modules/communities/pages/CommunitiesPages/CommunitiesSelectionPage/CommunitiesSelectionPage.test.tsx
@@ -9,9 +9,11 @@ import {
 import CommunityService from 'modules/communities/services/CommunityService';
 import {
   MockedFirstCommunity,
+  MockedLoggedInUserManager,
   MockedSecondCommunity,
 } from '../../../mocks/MockedCommunity';
 import CommunitySelectionPage from './CommunitiesSelectionPage';
+import { renderWithRouterAndAuth, setUserAuthenticated } from 'setupTests';
 
 jest.mock('../../../services/CommunityService');
 const mockedCommunityService = CommunityService as jest.Mocked<
@@ -21,6 +23,7 @@ const mockedCommunityService = CommunityService as jest.Mocked<
 describe('CommunitySelectionPage', () => {
   beforeEach(() => {
     mockedCommunityService.getAllCommunities.mockResolvedValue([]);
+    setUserAuthenticated();
   });
 
   describe(' Render Community Selection Page', () => {
@@ -38,7 +41,8 @@ describe('CommunitySelectionPage', () => {
         screen.getByText('Carregando, por favor aguarde...'),
       );
     });
-    it('should render a grid to show the communities', async () => {
+
+    it('should render only the grid after loading', async () => {
       mockedCommunityService.getAllCommunities.mockResolvedValue([
         MockedFirstCommunity,
       ]);
@@ -54,9 +58,58 @@ describe('CommunitySelectionPage', () => {
       expect(communitiesList).toBeInTheDocument();
     });
 
+    it('should render a community card if user is a community manager', async () => {
+      mockedCommunityService.getAllCommunities.mockResolvedValue([
+        MockedLoggedInUserManager,
+        MockedFirstCommunity,
+      ]);
+      await act(async () => {
+        renderWithRouterAndAuth(
+          <BrowserRouter>
+            <CommunitySelectionPage />
+          </BrowserRouter>,
+        );
+      });
+
+      const community = screen.getByTestId('community-card-grid');
+      const communityName = screen.getByRole('heading', {
+        name: /comunidade gerenciada/i,
+      });
+      const communityNameNotPresent = screen.queryByRole('heading', {
+        name: /XPTO/i,
+      });
+
+      expect(community).toBeInTheDocument();
+      expect(communityName).toBeInTheDocument();
+      expect(communityNameNotPresent).not.toBeInTheDocument();
+    });
+
+    it('should render an empty state if user is not a community manager', async () => {
+      setUserAuthenticated();
+      mockedCommunityService.getAllCommunities.mockResolvedValue([
+        MockedFirstCommunity,
+      ]);
+      await act(async () => {
+        renderWithRouterAndAuth(
+          <BrowserRouter>
+            <CommunitySelectionPage />
+          </BrowserRouter>,
+        );
+      });
+
+      const emptyStateText = 'Não há resultados';
+      const registerCommunity =
+        'Cadastre uma nova comunidade em nosso aplicaticativo.';
+      const communities = screen.queryByTestId('community-card-grid');
+
+      expect(screen.getByText(emptyStateText)).toBeInTheDocument();
+      expect(screen.getByText(registerCommunity)).toBeInTheDocument();
+      expect(communities).toBeFalsy();
+    });
+
     it('renders no communities and an empty state message', async () => {
       await act(async () => {
-        render(
+        renderWithRouterAndAuth(
           <BrowserRouter>
             <CommunitySelectionPage />
           </BrowserRouter>,
@@ -65,15 +118,18 @@ describe('CommunitySelectionPage', () => {
 
       const emptyStateText = 'Nenhuma comunidade cadastrada!';
       const registerCommunity = 'Cadastrar comunidade';
+      const communities = screen.queryByTestId('community-card-grid');
+
       expect(screen.getByText(emptyStateText)).toBeInTheDocument();
       expect(screen.getByText(registerCommunity)).toBeInTheDocument();
+      expect(communities).toBeFalsy();
     });
   });
 
   describe('Search bar', () => {
     it('should update page on change', async () => {
       await act(async () => {
-        render(
+        renderWithRouterAndAuth(
           <BrowserRouter>
             <CommunitySelectionPage />
           </BrowserRouter>,
@@ -95,7 +151,7 @@ describe('CommunitySelectionPage', () => {
         MockedSecondCommunity,
       ]);
       await act(async () => {
-        render(
+        renderWithRouterAndAuth(
           <BrowserRouter>
             <CommunitySelectionPage />
           </BrowserRouter>,
@@ -106,20 +162,22 @@ describe('CommunitySelectionPage', () => {
         'Que comunidade você está procurando?',
       ) as HTMLInputElement;
 
+      const community = screen.queryByTestId('community-card-grid');
+      expect(community).toBeInTheDocument();
+
       fireEvent.change(searchInput, { target: { value: 'Lorem Ipsum' } });
 
-      expect(
-        screen.getByText(/Não há resultados para essa busca: Lorem Ipsum./i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Não há resultados/i)).toBeInTheDocument();
     });
 
     it('should filter cards  when searching for community', async () => {
       mockedCommunityService.getAllCommunities.mockResolvedValue([
         MockedFirstCommunity,
         MockedSecondCommunity,
+        MockedLoggedInUserManager,
       ]);
       await act(async () => {
-        render(
+        renderWithRouterAndAuth(
           <BrowserRouter>
             <CommunitySelectionPage />
           </BrowserRouter>,
@@ -132,8 +190,9 @@ describe('CommunitySelectionPage', () => {
 
       let communitiesList = screen.getByTestId('communities-grid');
       expect(communitiesList.childElementCount).toBe(2);
-      expect(screen.queryByText(/XPTO/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Comunidade Gerenciada/i)).toBeInTheDocument();
       expect(screen.queryByText(/Nome teste/i)).toBeInTheDocument();
+      expect(screen.queryByText(/XPTO/i)).not.toBeInTheDocument();
 
       fireEvent.change(searchInput, { target: { value: 'teste' } });
 
@@ -142,6 +201,9 @@ describe('CommunitySelectionPage', () => {
       expect(communitiesList.childElementCount).toBe(1);
       expect(screen.queryByText(/XPTO/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/Nome teste/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Comunidade Gerenciada/i),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/modules/communities/pages/CommunitiesPages/CommunitiesSelectionPage/CommunitiesSelectionPage.tsx
+++ b/src/modules/communities/pages/CommunitiesPages/CommunitiesSelectionPage/CommunitiesSelectionPage.tsx
@@ -7,6 +7,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import { Loading, toast } from 'shared/components';
 import EmptyState from 'shared/components/EmptyState/EmptyState';
 import { EmptyStateImage } from 'shared/assets/images';
+import { useGetAuth } from 'modules/authentication/contexts/AuthContext';
 import Community from '../../../models/Community';
 import CommunityService from '../../../services/CommunityService';
 import CommunityCard from '../components/CommunityCard/CommunityCard';
@@ -20,13 +21,20 @@ const CommunitiesSelectionPage: React.FC = () => {
   const history = useHistory();
   const classes = useStyles();
   const lowerCased = textInput.toUpperCase();
+  const { value } = useGetAuth();
 
   const manageOnClick = community => {
     history.push(`comunidades/gerenciador-de-comunidade/${community.id}`);
   };
 
-  const filteredCommunities = communities.filter(com =>
-    com.name.toUpperCase().includes(lowerCased),
+  const isLoggedInUserCommunityManager = community => {
+    return value.email === community.org_email;
+  };
+
+  const filteredCommunities = communities.filter(
+    com =>
+      isLoggedInUserCommunityManager(com) &&
+      com.name.toUpperCase().includes(lowerCased),
   );
 
   const handleTextInput = e => {
@@ -103,6 +111,7 @@ const CommunitiesSelectionPage: React.FC = () => {
                 md={6}
                 sm={12}
                 className={classes.card}
+                data-testid="community-card-grid"
               >
                 <CommunityCard
                   key={community.id}
@@ -112,9 +121,11 @@ const CommunitiesSelectionPage: React.FC = () => {
               </Grid>
             ))
           ) : (
-            <Typography className={classes.emptySearch}>
-              Não há resultados para essa busca: {textInput}.
-            </Typography>
+            <EmptyState
+              imgSrc={EmptyStateImage}
+              heading="Não há resultados"
+              subheading="Cadastre uma nova comunidade em nosso aplicaticativo."
+            />
           )}
         </Grid>
       ) : (


### PR DESCRIPTION
## O que foi realizado?

As comunidades exibidas na seleção de comunidades após o login agora serão filtradas pelo usuário logado. Só usuários gestores poderão ver as comunidades nas quais gerenciam.

<!--- Descreva suas alterações em detalhes -->

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [ ] Foi realizado uma revisão por outra pessoa do meu código
- [x] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes são aprovados localmente com minhas alterações
