### PR TITLE
feat(communities): Allow admins to see all communities

### DIFF
--- a/src/modules/authentication/contexts/AuthContext.tsx
+++ b/src/modules/authentication/contexts/AuthContext.tsx
@@ -19,6 +19,7 @@ export const INITIAL_AUTH: AuthInterface = {
   authenticated: false,
   email: '',
   displayName: '',
+  uid: '',
 };
 
 const AuthContext = createContext<AuthContextType>([
@@ -86,11 +87,13 @@ const mapAuthValue = ({
   authenticated,
   email,
   displayName,
+  uid,
 }: AuthInterface) => ({
   token,
   authenticated,
   email,
   displayName,
+  uid,
 });
 
 export { AuthProvider, useAuth, useGetAuth, useHandleAuth, useClearAuth };

--- a/src/modules/authentication/models/AuthInterface.ts
+++ b/src/modules/authentication/models/AuthInterface.ts
@@ -3,4 +3,5 @@ export default interface AuthInterface {
   email: string;
   displayName: string;
   token: string;
+  uid: string;
 }

--- a/src/modules/authentication/services/LoginService.ts
+++ b/src/modules/authentication/services/LoginService.ts
@@ -16,6 +16,7 @@ const LoginService = {
       displayName: userDetails?.displayName || '',
       email: userDetails?.email || '',
       authenticated: userDetails?.emailVerified || false,
+      uid: userDetails?.uid || '',
     };
   },
 };

--- a/src/modules/communities/pages/CommunitiesPages/CommunitiesSelectionPage/CommunitiesSelectionPage.test.tsx
+++ b/src/modules/communities/pages/CommunitiesPages/CommunitiesSelectionPage/CommunitiesSelectionPage.test.tsx
@@ -6,6 +6,7 @@ import {
   waitForElementToBeRemoved,
   fireEvent,
 } from '@testing-library/react';
+import { UserService } from 'modules/users/services';
 import CommunityService from 'modules/communities/services/CommunityService';
 import { renderWithRouterAndAuth, setUserAuthenticated } from 'setupTests';
 import {
@@ -20,9 +21,13 @@ const mockedCommunityService = CommunityService as jest.Mocked<
   typeof CommunityService
 >;
 
+jest.mock('../../../../users/services/UserService');
+const mockedUserService = UserService as jest.Mocked<typeof UserService>;
+
 describe('CommunitySelectionPage', () => {
   beforeEach(() => {
     mockedCommunityService.getAllCommunities.mockResolvedValue([]);
+    mockedUserService.isUserAdmin.mockResolvedValue(false);
     setUserAuthenticated();
   });
 
@@ -105,6 +110,40 @@ describe('CommunitySelectionPage', () => {
       expect(screen.getByText(emptyStateText)).toBeInTheDocument();
       expect(screen.getByText(registerCommunity)).toBeInTheDocument();
       expect(communities).toBeFalsy();
+    });
+
+    it('should render all community cards if user is an admin', async () => {
+      mockedUserService.isUserAdmin.mockResolvedValue(true);
+      mockedCommunityService.getAllCommunities.mockResolvedValue([
+        MockedLoggedInUserManager,
+        MockedFirstCommunity,
+        MockedSecondCommunity,
+      ]);
+      await act(async () => {
+        renderWithRouterAndAuth(
+          <BrowserRouter>
+            <CommunitySelectionPage />
+          </BrowserRouter>,
+        );
+      });
+
+      const communityCardsQuantity = screen.queryAllByTestId(
+        'community-card-grid',
+      ).length;
+      const communityName1 = screen.getByRole('heading', {
+        name: /comunidade gerenciada/i,
+      });
+      const communityName2 = screen.queryByRole('heading', {
+        name: /XPTO/i,
+      });
+      const communityName3 = screen.queryByRole('heading', {
+        name: /Nome Teste/i,
+      });
+
+      expect(communityName1).toBeInTheDocument();
+      expect(communityName2).toBeInTheDocument();
+      expect(communityName3).toBeInTheDocument();
+      expect(communityCardsQuantity).toBeGreaterThanOrEqual(3);
     });
 
     it('renders no communities and an empty state message', async () => {

--- a/src/modules/users/services/UserService.test.ts
+++ b/src/modules/users/services/UserService.test.ts
@@ -28,6 +28,39 @@ describe('User Service', () => {
     await waitFor(() => expect(data).toStrictEqual(mockedUsers));
   });
 
+  it('should validate if user is admin', async () => {
+    const isAdminMockedResponse = {
+      data: {
+        userId: {
+          email: 'admin@teste.com',
+          uid: 'userId',
+        },
+      },
+    };
+
+    mockedApi.get.mockResolvedValue(isAdminMockedResponse);
+    let data: boolean;
+
+    await act(async () => {
+      data = await UserService.isUserAdmin('userId');
+    });
+
+    expect(mockedApi.get).toHaveBeenCalledWith('/admins/userId.json');
+    await waitFor(() => expect(data).toBeTruthy());
+  });
+
+  it('should validate if user is not an admin', async () => {
+    mockedApi.get.mockResolvedValue([]);
+    let data: boolean;
+
+    await act(async () => {
+      data = await UserService.isUserAdmin('userNotAdminId');
+    });
+
+    expect(mockedApi.get).toHaveBeenCalledWith('/admins/userNotAdminId.json');
+    await waitFor(() => expect(data).toBeFalsy());
+  });
+
   it('should get user by ID', async () => {
     mockedApi.get.mockResolvedValue({
       data: {

--- a/src/modules/users/services/UserService.ts
+++ b/src/modules/users/services/UserService.ts
@@ -13,6 +13,15 @@ const UserService = {
     return users;
   },
 
+  async isUserAdmin(userId: string) {
+    try {
+      const { data } = await api.get(`/admins/${userId}.json`);
+      return Object.keys(data).length > 0;
+    } catch (error) {
+      return false;
+    }
+  },
+
   async getUserById(id: string) {
     const { data } = await api.get(`/users/${id}.json`);
 


### PR DESCRIPTION
## O que foi realizado?

Este PR adiciona uma lógica que permite os usuários cadastrados como admins a verem todas a comunidades cadastradas durante o processo de seleção.

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [ ] Foi realizado uma revisão por outra pessoa do meu código
- [x] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes são aprovados localmente com minhas alterações
