### PR TITLE
fix: No bikes found message for SelectBikePage

### DIFF
--- a/src/modules/bicycles/components/SelectBikePage/SelectBikePage.test.tsx
+++ b/src/modules/bicycles/components/SelectBikePage/SelectBikePage.test.tsx
@@ -1,10 +1,5 @@
 import { BrowserRouter } from 'react-router-dom';
-import {
-  act,
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { act, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { renderWithRouterAndAuth } from 'setupTests';
 import BikeService from '../../services/BikeService';
 import { mockedBike } from '../../mocks/BikeMocks';

--- a/src/modules/bicycles/components/SelectBikePage/SelectBikePage.test.tsx
+++ b/src/modules/bicycles/components/SelectBikePage/SelectBikePage.test.tsx
@@ -17,13 +17,11 @@ describe('SelectBikePage', () => {
   describe('when has state params', () => {
     it('should render correctly', async () => {
       mockedBikeService.getBikesPerCommunity.mockResolvedValue([mockedBike()]);
-      await act(() => {
-        renderWithRouterAndAuth(
-          <BrowserRouter>
-            <SelectBikePage communityId="-MLDOXs3p35DEHg0gdUU" />
-          </BrowserRouter>,
-        );
-      });
+      renderWithRouterAndAuth(
+        <BrowserRouter>
+          <SelectBikePage communityId="-MLDOXs3p35DEHg0gdUU" />
+        </BrowserRouter>,
+      );
 
       await waitForElementToBeRemoved(() =>
         screen.getByText('Carregando, por favor aguarde...'),
@@ -33,17 +31,41 @@ describe('SelectBikePage', () => {
       expect(card).toBeInTheDocument();
     });
 
-    it('should render list of bikes', async () => {
+    it('should render list of bikes when returned by endpoint', async () => {
       mockedBikeService.getBikesPerCommunity.mockResolvedValue([mockedBike()]);
 
       await act(async () => {
-        render(
+        renderWithRouterAndAuth(
           <BrowserRouter>
             <SelectBikePage communityId="-MLDOXs3p35DEHg0gdUU" />
           </BrowserRouter>,
         );
       });
       expect(screen.getByTestId('bikeList')).toBeInTheDocument();
+      expect(screen.getByText('Selecione a bicicleta')).toBeInTheDocument();
+    });
+
+    it('should render no bikes found message', async () => {
+      mockedBikeService.getBikesPerCommunity.mockResolvedValue([]);
+
+      await act(async () => {
+        renderWithRouterAndAuth(
+          <BrowserRouter>
+            <SelectBikePage communityId="-MLDOXs3p35DEHg0gdUU" />
+          </BrowserRouter>,
+        );
+      });
+      expect(
+        screen.queryByText('Selecione a bicicleta'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText('Nenhuma bicicleta disponível!'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Verifique as bicicletas cadastradas e tente novamente.',
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/modules/bicycles/components/SelectBikePage/SelectBikePage.tsx
+++ b/src/modules/bicycles/components/SelectBikePage/SelectBikePage.tsx
@@ -4,9 +4,10 @@ import { useHistory } from 'react-router-dom';
 import Bike from 'modules/users/models/Bike';
 import BikeService from 'modules/bicycles/services/BikeService';
 import toast from 'shared/components/Toast/Toast';
-import { Loading } from 'shared/components';
+import { EmptyState, Loading } from 'shared/components';
 import { User } from 'modules/users/models';
 import { FormValues } from 'modules/bicycles/pages/ReturnBike/ReturnBikeStepOne/ReturnBikeForm.schema';
+import { EmptyStateImage } from 'shared/assets/images';
 import BikeCard from '../BikeCard/BikeCard';
 import useStyles from './SelectBikePage.styles';
 
@@ -60,13 +61,21 @@ const SelectBikeCard: React.FC<SelectBikeProps> = ({
   return (
     <>
       <div className={classes.cardPosition} data-testid="bikeList">
-        <Typography component="h5" variant="h5" className={classes.titleStyle}>
-          Selecione a bicicleta
-        </Typography>
+        {bikes.length ? (
+          <Typography
+            component="h5"
+            variant="h5"
+            className={classes.titleStyle}
+          >
+            Selecione a bicicleta
+          </Typography>
+        ) : (
+          ''
+        )}
         <>
           {loading ? (
             <Loading />
-          ) : (
+          ) : bikes.length ? (
             bikes?.map(item => {
               return (
                 <BikeCard
@@ -80,6 +89,12 @@ const SelectBikeCard: React.FC<SelectBikeProps> = ({
                 />
               );
             })
+          ) : (
+            <EmptyState
+              imgSrc={EmptyStateImage}
+              heading="Nenhuma bicicleta disponível!"
+              subheading="Verifique as bicicletas cadastradas e tente novamente."
+            />
           )}
         </>
       </div>

--- a/src/modules/bicycles/components/SelectBikePage/SelectBikePage.tsx
+++ b/src/modules/bicycles/components/SelectBikePage/SelectBikePage.tsx
@@ -75,7 +75,7 @@ const SelectBikeCard: React.FC<SelectBikeProps> = ({
         <>
           {loading ? (
             <Loading />
-          ) : bikes.length ? (
+          ) : (
             bikes?.map(item => {
               return (
                 <BikeCard
@@ -89,7 +89,9 @@ const SelectBikeCard: React.FC<SelectBikeProps> = ({
                 />
               );
             })
-          ) : (
+          )}
+
+          {!bikes.length && !loading && (
             <EmptyState
               imgSrc={EmptyStateImage}
               heading="Nenhuma bicicleta disponível!"


### PR DESCRIPTION
## O que foi realizado?

Ajuste no componente SelectBikePage para que mostre mensagem de que nenhuma bicicleta está disponível quando todas estiverem emprestadas/devolvidas, a depender da página em que é utilizado.

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [x] Foi realizado uma revisão por outra pessoa do meu código
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes são aprovados localmente com minhas alterações

## Checklist Frontend

- [x] Inseri na PR captura de tela da feature desenvolvida
![image](https://user-images.githubusercontent.com/104450601/193118709-82f09fe2-5a29-495b-912a-a105e0fde475.png)

