### PR TITLE
837 - Add motivation props inside UserQuiz

### DIFF
--- a/src/modules/users/mocks/MockedUser.ts
+++ b/src/modules/users/mocks/MockedUser.ts
@@ -20,6 +20,7 @@ export const mockedUser = (): User => ({
   userQuiz: {
     alreadyUseBPR: false,
     alreadyUseBPROpenQuestion: 'Trabalho',
+    motivation: 5,
     motivationOpenQuestion: 'trabalho',
     alreadyAccidentVictim: true,
     problemsOnWayOpenQuestion: 'Não',

--- a/src/modules/users/models/User.ts
+++ b/src/modules/users/models/User.ts
@@ -1,6 +1,7 @@
 export interface UserQuiz {
   alreadyUseBPR: boolean;
   alreadyUseBPROpenQuestion: string;
+  motivation: number;
   motivationOpenQuestion: string;
   alreadyAccidentVictim: boolean;
   problemsOnWayOpenQuestion: string;

--- a/src/modules/users/pages/UserPage/components/UserCard/UserCard.tsx
+++ b/src/modules/users/pages/UserPage/components/UserCard/UserCard.tsx
@@ -5,34 +5,11 @@ import { LockOutlined, PlaceOutlined } from '@material-ui/icons';
 import { toast } from 'shared/components';
 import UserMenu from '../UserMenu/UserMenu';
 import UserService from '../../../../services/UserService';
+import User from '../../../../models/User';
 import useStyles, { StyledBadgeUserCard } from './UserCard.styles';
 
 interface UserCardProps {
-  user: {
-    name: string;
-    createDate: string;
-    address: string;
-    gender: string;
-    profilePicture: string;
-    age: string;
-    racial: string;
-    schooling: string;
-    schoolingStatus: string;
-    income: string;
-    communityId: string;
-    telephone: string;
-    status: boolean;
-    id: string;
-    isBlocked: boolean;
-    userQuiz: {
-      alreadyUseBPR: boolean;
-      alreadyUseBPROpenQuestion: string;
-      motivationOpenQuestion: string;
-      alreadyAccidentVictim: boolean;
-      problemsOnWayOpenQuestion: string;
-      timeOnWayOpenQuestion: string;
-    };
-  };
+  user: User;
 }
 
 const UserCard: React.FC<UserCardProps> = ({ user, ...rest }) => {


### PR DESCRIPTION
## O que foi realizado?

No cartão #837 foram feitas alguns ajustes referentes ao Motivation. Validamos novamente essas alterações e refatoramos a estrutura das Props utilizadas dentro do componente `UserCard`, para utilizar a interface já existente `User`.
Pareando com  a @naiaraap

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [ ] Foi realizado uma revisão por outra pessoa do meu código
- [x] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
- [x] Meu código segue as diretrizes de estilo deste projeto
- [ ] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes são aprovados localmente com minhas alterações

## Checklist Frontend

- Não houve alterações visuais na aplicação.
