### PR TITLE
#861 - Separate component Simple Dialog

### DIFF
--- a/src/modules/authentication/pages/PasswordResetPage/PasswordResetPage.tsx
+++ b/src/modules/authentication/pages/PasswordResetPage/PasswordResetPage.tsx
@@ -1,11 +1,6 @@
 import React, { useState } from 'react';
 import {
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
   FormHelperText,
   Paper,
   TextField,
@@ -15,46 +10,8 @@ import ErrorIcon from '@material-ui/icons/Error';
 import { useHistory } from 'react-router-dom';
 import { useFormControls } from 'modules/authentication/hooks/index';
 import LoginService from 'modules/authentication/services/LoginService';
+import SimpleDialog from '../../../../shared/components/SimpleDialog/SimpleDialog';
 import useStyles from './PasswordResetPage.styles';
-
-export interface SimpleDialogProps {
-  open: boolean;
-  title: string;
-  content: string;
-  onClose: (value: string) => void;
-}
-
-function SimpleDialog(props: SimpleDialogProps) {
-  const { onClose, title, content, open } = props;
-
-  const handleClose = () => {
-    onClose('');
-  };
-
-  return (
-    <Dialog
-      open={open}
-      onClose={handleClose}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-      data-testid="dialog"
-    >
-      <DialogTitle id="alert-dialog-title" data-testid="alert-dialog-title">
-        {title}
-      </DialogTitle>
-      <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          {content}
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose} color="primary" variant="contained">
-          Fechar
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-}
 
 const PasswordResetPage: React.FC = () => {
   const [open, setOpen] = useState(false);

--- a/src/shared/components/SimpleDialog/SimpleDialog.styles.ts
+++ b/src/shared/components/SimpleDialog/SimpleDialog.styles.ts
@@ -1,0 +1,8 @@
+import { makeStyles } from '@material-ui/core';
+
+export default makeStyles(() => ({
+  root: {
+    margin: '0 24px 24px 0',
+    padding: 0,
+  },
+}));

--- a/src/shared/components/SimpleDialog/SimpleDialog.test.tsx
+++ b/src/shared/components/SimpleDialog/SimpleDialog.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import SimpleDialog from './SimpleDialog';
+
+describe('Simple Dialog', () => {
+  it('should render Dialog correctly', () => {
+    render(
+      <SimpleDialog
+        open
+        title="title"
+        content="Lorem Ipsum"
+        onClose={() => jest.fn()}
+      />,
+    );
+
+    const wrapper = screen.getByTestId('dialog');
+
+    expect(wrapper).toBeInTheDocument();
+  });
+});

--- a/src/shared/components/SimpleDialog/SimpleDialog.tsx
+++ b/src/shared/components/SimpleDialog/SimpleDialog.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core';
+import useStyles from './SimpleDialog.styles';
+
+interface SimpleDialogProps {
+  open: boolean;
+  title: string;
+  content: string;
+  onClose: (value: string) => void;
+}
+
+const SimpleDialog: React.FC<SimpleDialogProps> = (
+  props: SimpleDialogProps,
+) => {
+  const { onClose, title, content, open } = props;
+  const classes = useStyles();
+
+  const handleClose = () => {
+    onClose('');
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+      data-testid="dialog"
+    >
+      <DialogTitle id="alert-dialog-title" data-testid="alert-dialog-title">
+        {title}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          {content}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions className={classes.root}>
+        <Button onClick={handleClose} color="primary" variant="contained">
+          Fechar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default SimpleDialog;


### PR DESCRIPTION
## O que foi realizado?

O componente Simple Dialog foi construído dentro do componente de PasswordResetPage, porém foi necessário alguns ajustes de estilo em relação a modal, e a existência desse componente dentro de outro dificultou essas mudanças. Sendo assim, foi proposta a separação, tendo em vista que por ser um componente genérico de construção de Dialog, poderia ser um componente reaproveitado em outros componentes.

## Checklist

- [x] Realizei uma auto-revisão do meu código
- [ ] Foi realizado uma revisão por outra pessoa do meu código
- [x] Fiz as alterações correspondentes na [documentação](https://docs.google.com/document/d/1u5xQt_3wQT_FJdKiu6U8Qut07MNALmpjv5qIaZzepJc/edit#heading=h.v0v8hzy8gdby)
- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona
- [x] Testes de unidade novos e existentes são aprovados localmente com minhas alterações

## Checklist Frontend

- [x] Inseri na PR captura de tela da feature desenvolvida
<img width="541" alt="Captura de Tela 2023-01-18 às 11 05 19" src="https://user-images.githubusercontent.com/81307139/213191983-bf00de95-ebd5-4dcf-8387-e63f045dbcbf.png">
<img width="505" alt="Captura de Tela 2023-01-18 às 11 05 04" src="https://user-images.githubusercontent.com/81307139/213192016-1c4dfd5b-eec4-4067-9c1e-c7d2e7b95cbc.png">
